### PR TITLE
SSL fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,13 @@ RUN mkdir /tmp/informix-odbc \
     && rm -R /tmp/informix-odbc \
     && rm /tmp/informix-odbc.tar
 
+# Fix SSL configuration to be compatible with older servers
+RUN \
+    # https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
+    sed -i 's/CipherString\s*=.*/CipherString = DEFAULT@SECLEVEL=1/g' /etc/ssl/openssl.cnf \
+    # https://stackoverflow.com/questions/53058362/openssl-v1-1-1-ssl-choose-client-version-unsupported-protocol
+    && sed -i 's/MinProtocol\s*=.*/MinProtocol = TLSv1/g' /etc/ssl/openssl.cnf
+
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/


### PR DESCRIPTION
Changes:
- Fixed SSL - so weaker ciphers connect.
- The client has problems connecting via SSH (uses libssl) tunnel and we want to rule out that the problem is only in the weak cipher.