### PR TITLE
Replace test connection query

### DIFF
--- a/src/Extractor/OdbcConnection.php
+++ b/src/Extractor/OdbcConnection.php
@@ -8,4 +8,10 @@ class OdbcConnection extends \Keboola\DbExtractor\Adapter\ODBC\OdbcConnection
 {
     use QuoteTrait;
     use QuoteIdentifierTrait;
+
+    public function testConnection(): void
+    {
+        // SELECT 1 is not working in some Informix databases
+        $this->query("SELECT DBINFO('dbname') FROM systables WHERE tabid = 1;", 1);
+    }
 }


### PR DESCRIPTION
Changes:
- Replaced test connection query `SELECT 1` -> `SELECT DBINFO('dbname') FROM systables WHERE tabid = 1;`.
- It is working on empty database too. `tabid` = `1` is system table, ... it is covered by `test-connection-ok` datadir test.