### PR TITLE
Use IBM Data Server CLI Driver

### DIFF
--- a/src/OdbcDsnFactory.php
+++ b/src/OdbcDsnFactory.php
@@ -8,7 +8,7 @@ use Keboola\DbExtractor\Configuration\OdbcDatabaseConfig;
 
 class OdbcDsnFactory
 {
-    public const ODBC_DRIVER_NAME = 'IBM Informix Informix ODBC DRIVER';
+    public const ODBC_DRIVER_NAME = 'IBM DRIVER';
 
     public function create(OdbcDatabaseConfig $dbConfig): string
     {
@@ -20,7 +20,7 @@ class OdbcDsnFactory
             $dbConfig->getServerName(),
             $dbConfig->getPort(),
             $dbConfig->getDatabase(),
-            $dbConfig->getProtocol(),
+            'TCPIP',
             $dbConfig->getDbLocale(),
             // Solution of "character conversion error":
             // specify explicitly for Client Locale the same locate as for Database Locale


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-406

Zistil som, ze:
- IBM ma okrem [Informix Client SDK](https://www.ibm.com/support/pages/informix-client-software-development-kit-client-sdk-and-informix-connect-system-requirements) ODBC ovladaca (ktory ma nejasnu licenciu).
- ... aj [IBM Data Server CLI Driver](https://www.ibm.com/support/pages/db2-odbc-cli-driver-download-and-installation-information), ktory sa da free stiahnut.
- Tento ovladac sluzi na pripojenie k `DB2` a `Informixu`
- Vyskusal som teda ovladac vymenit, aby sme mohli pouzivat tento druhy, ktory je jednoznacne free.
- V tomto PR som ovladac vymenil, no zistil som, ze s Informixom vie komunikovat iba cez `drsoctcp` protokol, no my potrebujeme `onsoctcp`, ktory funguje bez potreby konfigurovania servera.
- Teda tadial cesta nevedie, nechavam tu tento PR, ak by sme niekedy potrebovali tento druhy ovladac, ... napr. na pripojenie k DB2.